### PR TITLE
[FEATURE] Stop container, if Spigot crashes

### DIFF
--- a/spigot_init.sh
+++ b/spigot_init.sh
@@ -30,7 +30,3 @@ chown -R minecraft.minecraft /$SPIGOT_HOME/
 
 cd /$SPIGOT_HOME/
 su - minecraft -c 'java -Xms512M -Xmx1536M -XX:MaxPermSize=128M -jar spigot.jar'
-
-# fallback to root and run shell if spigot don't start/forced exit
-bash
-


### PR DESCRIPTION
Isn't it better to stop the container, when the JAR-File crashes?
Otherwise we are running a useless container with a bash.

By using "docker run --restart always [...]"  in combination with this commit it will restart automatically

You can get a bash inside the Container by using docker exec -it bash CONTAINERNAME