### PR TITLE
Healthcheck in Docker for spigot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && \
     # remove apt cache from image
     apt-get clean all
 
+# Docker Healthcheck:
+HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 
 # expose minecraft port
 EXPOSE 25565

--- a/rootfs/usr/local/bin/healthcheck.sh
+++ b/rootfs/usr/local/bin/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Basic healthcheck for docker, remove # from echo if you want some sort of output
-# during build, it will show as unhealthy in docker ps
+# Basic healthcheck for docker, remove # from echo if you want some sort of output.
+# During build, it will show as unhealthy in docker ps
 
 if /usr/bin/supervisorctl status spigot | grep -q 'RUNNING'; then
  # echo "matched"

--- a/rootfs/usr/local/bin/healthcheck.sh
+++ b/rootfs/usr/local/bin/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Basic healthcheck for docker, remove # from echo if you want some sort of output
+# during build, it will show as unhealthy in docker ps
+
+if /usr/bin/supervisorctl status spigot | grep -q 'RUNNING'; then
+ # echo "matched"
+  exit 0
+else
+ # echo "failed"
+  exit 1
+fi


### PR DESCRIPTION
Very basic healthcheck for docker.
Uses supervisorctl status to check if spigot is running or not.

Will show unhealthy during build.