### PR TITLE
Fixed an error that prevents building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/rootfs/etc/init.d/minecraft_server
+++ b/rootfs/etc/init.d/minecraft_server
@@ -211,7 +211,7 @@ buildjar() {
     export HOME
     cd $HOME
     git config --global --unset core.autocrlf
-    java -jar BuildTools.jar --rev $1
+    java -Xmx1024M -jar BuildTools.jar --rev $1
     cp /build-mc/Spigot/Spigot-Server/target/spigot-*.jar $SPIGOT_HOME/spigot-$1.jar
     cd $SPIGOT_HOME/
     rm -Rf /build-mc


### PR DESCRIPTION
**Error logs from running latest image**:
```sh
2019-07-11 00:19:52 (15.5 MB/s) - '/build-mc/BuildTools.jar' saved [3994428/3994428]

BuildTools requires at least 512M of memory to run (1024M recommended), but has only detected 444M.
This can often occur if you are running a 32-bit system, or one with low RAM.
Please re-run BuildTools with manually specified memory, e.g: java -Xmx1024M -jar BuildTools.jar --rev latest
cp: cannot stat '/build-mc/Spigot/Spigot-Server/target/spigot-*.jar': No such file or directory
*** Running /etc/my_runalways/85_fix_startsh...
start.sh missing, creating link for /minecraft/start.sh
*** Running /etc/my_runalways/90_eula...
*** Running /etc/rc.local...
*** Booting supervisor daemon...
*** Supervisor started as PID 66
2019-07-11 00:20:01,211 CRIT Set uid to user 0
*** Started processes via Supervisor......
crond                            RUNNING   pid 70, uptime 0:00:04
spigot                           BACKOFF   Exited too quickly (process log may have details)
syslog-ng                        RUNNING   pid 69, uptime 0:00:04
```

>This merge request is manually tested

I built my fix into a docker image and ran the container. I have attached the logs below:
```sh
Success! Everything compiled successfully. Copying final .jar files now.
Copying craftbukkit-1.13.2-R0.1-SNAPSHOT.jar to /build-mc/./craftbukkit-1.13.2.jar
  - Saved as ./craftbukkit-1.13.2.jar
Copying spigot-1.13.2-R0.1-SNAPSHOT.jar to /build-mc/./spigot-1.13.2.jar
  - Saved as ./spigot-1.13.2.jar
*** Running /etc/my_runalways/85_fix_startsh...
start.sh missing, creating link for /minecraft/start.sh
*** Running /etc/my_runalways/90_eula...
*** Running /etc/rc.local...
*** Booting supervisor daemon...
*** Supervisor started as PID 580
2019-07-11 00:42:31,033 CRIT Set uid to user 0
*** Started processes via Supervisor......
crond                            RUNNING   pid 584, uptime 0:00:03
spigot                           RUNNING   pid 585, uptime 0:00:03
syslog-ng                        RUNNING   pid 583, uptime 0:00:03
```

@nimmis 