### PR TITLE
Add UTF-8 support and several changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ ENV LC_ALL en_US.UTF-8
 # SPIGOT_AUTORESTART  set to yes to restart if minecraft stop command is executed
 ENV SPIGOT_HOME=/minecraft \
     SPIGOT_VER=latest \
-    SPIGOT_AUTORESTART=yes
+    SPIGOT_AUTORESTART=yes \
+    MC_MAXMEM= \
+    MC_MINMEM= \
+    OTHER_JAVA_OPS=
 
 # add extra files needed
 COPY rootfs /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@ FROM nimmis/java:openjdk-8-jdk
 
 MAINTAINER nimmis <kjell.havneskold@gmail.com>
 
+# Solution of UTF-8 support in docker
+# Reference: https://stackoverflow.com/a/28406007
+RUN apt-get update && apt-get install locales
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # SPIGOT_HOME         default directory for SPIGOT-server
 # SPIGOT_VER          default minecraft version to compile
 # SPIGOT_AUTORESTART  set to yes to restart if minecraft stop command is executed
@@ -28,7 +36,6 @@ RUN apt-get update && \
 
     # remove apt cache from image
     apt-get clean all
-
 
 # expose minecraft port
 EXPOSE 25565

--- a/rootfs/etc/init.d/minecraft_server
+++ b/rootfs/etc/init.d/minecraft_server
@@ -31,8 +31,8 @@ if [ -z  "$MC_MINMEM" ]; then
   MC_MINMEM=$MC_MAXMEM ;
 fi
 
-
-MC_JAVA_OPS="-Xmx$MC_MAXMEM -Xms$MC_MINMEM"   # java options for minecraft server
+# Add $OTHER_JAVA_OPS to let the user determine what options they need
+MC_JAVA_OPS="-Xmx$MC_MAXMEM -Xms$MC_MINMEM $OTHER_JAVA_OPS"   # java options for minecraft server
 
 JAVACMD=$(which java)
 
@@ -393,8 +393,9 @@ case "$1" in
   ;;
 
   log)
+     # tail will not work after log file delete, use -F to keep it working
      echo "Abort with CTRL-C"
-     tail -f $MC_DIR/output.con
+     tail -F $MC_DIR/output.con
   ;;
 
   console)

--- a/rootfs/usr/local/bin/mc_send
+++ b/rootfs/usr/local/bin/mc_send
@@ -8,5 +8,4 @@
 ###########################################################
 
 echo "/etc/init.d/minecraft_server send \"$1\""
-/etc/init.d/minecraft_server send "$1 $2 $3 $4 $5"
-mc_log
+/etc/init.d/minecraft_server send "$*"


### PR DESCRIPTION
Thanks to this work to let me build my server more easily, and I learn a lot from this repo!
I found that the UTF-8 character is not working under this image, and it is not friendly for server localization.
After some research, I found [a solution](https://stackoverflow.com/a/28406007) to address this issue.
So I add these to Dockerfile, and my plugins and commands with UTF-8 character finally work.

I add environment variable `$OTHER_JAVA_OPS` to let the user decide what options they want to add, such as gc collection.

due to the `output.con` will be deleted when `mc_restart`, `mc_log` will be not working, add `-F` option to `tail`.

I think that showing the logs after mc_send is unnecessary since they can simply do it by `mc_send && mc_log`, and without `mc_log` following by `mc_send`, the user can even write a script to run commands on the host.

Thanks for your work again!