### PR TITLE
Bump Java version to 17 for Minecraft 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV SPIGOT_HOME=/minecraft \
 ENV DEBIAN_FRONTEND noninteractive
 
 # set default java environment variable
-ENV JAVA_VERSION_MAJOR=16 \
+ENV JAVA_VERSION_MAJOR=17 \
     JAVA_TYPE="" \
     JAVA_OPT=hotspot \
     JAVA_HOME=/usr/lib/jvm/default-jvm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,36 +51,28 @@ RUN apt-get update && \
     export CNAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) && \
 
     # req. packages
-    apt-get install -y wget apt-transport-https gnupg && \
+    apt-get install -y wget apt-transport-https gnupg curl && \
 
-    # get pgp key
+    # add Azul's public key
+    apt-key adv \
+        --keyserver hkp://keyserver.ubuntu.com:80 \
+        --recv-keys 0xB1998361219BD9C9 && \
 
-    wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
-    gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public && \
-    gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg && \
-    rm public adoptopenjdk-keyring.gpg && \
-    mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && \
+    # download and install the package that adds 
+    # the Azul APT repository to the list of sources 
+    curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb && \
 
-    # Configure AdoptOpenJDK's apt repository
-    echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb $CNAME main" | \
-      tee /etc/apt/sources.list.d/adoptopenjdk.list && \
+    # install the package
+    apt-get install -y ./zulu-repo_1.0.0-3_all.deb && \
 
     # refresh
     apt-get update && \
 
-    # install
-    apt-get install -y adoptopenjdk-$JAVA_VERSION_MAJOR-$JAVA_OPT$JAVA_TYPE && \
-
-    # set compatible home path
-    ln -s /usr/lib/jvm/adoptopenjdk-$JAVA_VERSION_MAJOR-$JAVA_OPT$JAVA_TYPE-amd64 /usr/lib/jvm/default-jvm && \
-
-
-
+    # install Azul Zulu JDK $JAVA_VERSION_MAJOR-$JAVA_OPT$JAVA_TYPE
+    apt-get install -y zulu$JAVA_VERSION_MAJOR-jdk && \
 
     # remove apt cache from image
     apt-get clean all
 
 # expose minecraft port
 EXPOSE 25565
-
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## Minecraft server SPIGOT on Ubuntu 20.04 with OpenJDK 1.16
+## Minecraft server SPIGOT on Ubuntu 20.04 with OpenJDK 1.17
 [![](https://images.microbadger.com/badges/image/nimmis/spigot.svg)](https://microbadger.com/images/nimmis/spigot "Get your own image badge on microbadger.com")
 
-**NOW works with Minecraft 1.17**
+**NOW works with Minecraft 1.18**
 
 This docker image builds and runs the spigot version of minecraft. 
 
@@ -10,11 +10,11 @@ released minecraft.jar
 
 Each time the container is started the presence of the file /minecraft/spigot.jar, if the file is missing a build of spigot.jar is started.
 
-The spigot daemon is started with superovisord, see my Ubuntu container for a more detailed description of my implementation of an init-process in ubuntu, see [nimmis/ubuntu](https://hub.docker.com/r/nimmis/ubuntu/)
+The spigot daemon is started with supervisored, see my Ubuntu container for a more detailed description of my implementation of an init-process in ubuntu, see [nimmis/ubuntu](https://hub.docker.com/r/nimmis/ubuntu/)
 
 Whats new is
 
-- Updated java version to 16 to compile minecraft 1.17
+- Updated java version to 16 to compile minecraft 1.18
 - Switched to Adopt OpenJDK
 - Fix for problem introduced during fall of 2017 for both Windows 10 and MacOS versions of docker, failed to build new versions of spigot 
 - Autodetection of timezone if container has access to internet
@@ -26,7 +26,6 @@ Whats new is
    - start/stop/restart the spigot server
    - send console commands to the server
    - look at console output from the server
-- 
 
 ## Why not a precompiled version of spigot is included
 


### PR DESCRIPTION
Minecraft 1.18 is out today and [requires Java 17](https://www.spigotmc.org/threads/9-years-of-spigotmc-spigot-bungeecord-1-18.534760/). I bumped the version environment variable which should hopefully do the trick I guess? Will try out later and make adjustments as necessary.