### PR TITLE
fix for minecraft 1.8.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Minecraft server SPIGOT on Ubuntu 20.04 with OpenJDK 11/16/17
+## Minecraft server SPIGOT on Ubuntu 20.04 with OpenJDK 8/11/16/17
 
 ![](https://img.shields.io/docker/pulls/nimmis/spigot?style=flat-square)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **NOW works with Minecraft 1.18**
 
-Need **-e SPIGOT_VERSION=1.18** to build because spigot still consider 1.17 as last stable version.
+Need **-e SPIGOT_VER=1.18** to build because spigot still consider 1.17 as last stable version.
 
 This is a major change in logic to build the correct version of spigot so some combination of conditions may not compile correctly. Please make an issue so I can correct it. There will be another build shortly with another feature
 

--- a/rootfs/usr/local/bin/set_mc_ver
+++ b/rootfs/usr/local/bin/set_mc_ver
@@ -25,6 +25,10 @@ function load_java() {
       /usr/local/bin/set_java_ver 16
       ;;
 
+    1.8*)
+      /usr/local/bin/set_java_ver 8
+      ;;
+
     *)
       /usr/local/bin/set_java_ver 11
       ;;


### PR DESCRIPTION
Hi,

When running server in, version 1.8, I'm getting the following error :
`*** The version you have requested to build requires Java versions between [Java 7, Java 8], but you are using Java 11
*** Please rerun BuildTools using an appropriate Java version. For obvious reasons outdated MC versions do not support Java versions that did not exist at their release.
cp: cannot stat '/build-mc/spigot-*.jar': No such file or directory
*** Running /etc/my_runalways/85_fix_startsh...
*** Running /etc/my_runalways/90_eula...
*** Booting supervisor daemon...
*** Supervisor started as PID 221
*** Started processes via Supervisor......
crond                            RUNNING   pid 223, uptime 0:00:04
spigot                           BACKOFF   Exited too quickly (process log may have details)
syslog-ng                        RUNNING   pid 225, uptime 0:00:04
`

That seems to come from uncompatible java version (default 11) with buildtools for spigot 1.8.

I just added setting java 8 as default for all 1.8 versions.

Thanks a lot for your job !