### PR TITLE
Support multiarch builds to run on other architectures e.g. Raspberry Pi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,19 +57,15 @@ RUN apt-get update && \
 
     # get pgp key
 
-    # create java directory
-    mkdir -p /usr/lib/jvm/ && \
-
-    # download jdk and unpack in /usr/lib/jvm
-    curl -L https://github.com/adoptium/temurin${JAVA_VERSION_MAJOR}-binaries/releases/download/jdk-${JAVA_VERSION_MAJOR}.${JAVA_VERSION_MINOR}%2B${JAVA_VERSION_UPDATE}/OpenJDK${JAVA_VERSION_MAJOR}U-jdk_x64_linux_${JAVA_OPT}_${JAVA_VERSION_MAJOR}.${JAVA_VERSION_MINOR}_${JAVA_VERSION_UPDATE}.tar.gz | tar xz -C /usr/lib/jvm/ && \
-
-    # set compatible home path
-    ln -s /usr/lib/jvm/jdk-${JAVA_VERSION_MAJOR}.${JAVA_VERSION_MINOR}+${JAVA_VERSION_UPDATE} /usr/lib/jvm/default-jvm && \
-    ln -s /usr/lib/jvm/default-jvm/bin/java /usr/bin/java && \
-
-
     # remove apt cache from image
     apt-get clean all
+
+RUN mkdir -p /usr/lib/jvm/ && \
+
+    # Install java
+    /usr/local/bin/set_java_ver ${JAVA_VERSION_MAJOR} && \
+
+    ln -s /usr/lib/jvm/default-jvm/bin/java /usr/bin/java
 
 # expose minecraft port
 EXPOSE 25565

--- a/README.md
+++ b/README.md
@@ -328,6 +328,21 @@ and you should get an output simular to
 
 and the versionlist is updated.
 
+## Building the Docker Image
+To build this image for your machine you can simply use the normal docker build command
+
+	docker build -t spigot ./
+
+If you want to build this image for multiple architectures you need to use a slightly different set of commands. However this allows you to push a single image from which clients can automatically select the correct architecture.
+
+First set up a binfmt container which allows other architectures to be emulated
+
+	docker run --privileged --rm tonistiigi/binfmt --install all
+
+Then build the images and push (docker doesn't currently support loading multi-arch images directly)
+
+	docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 --tag scratchcat1/minecraft-spigot:latest --push ./
+
 ## Old versions news
 
 - Updated java version to 17 which is a LTS version

--- a/rootfs/usr/local/bin/set_java_ver
+++ b/rootfs/usr/local/bin/set_java_ver
@@ -6,10 +6,30 @@
 # (c) 2021 nimmis <kjell.havneskold@gmail.com>
 #
 ###########################################################
+
+function get_cpu_arch_for_java () {
+  cpu_arch_line=$(lscpu | grep Architecture)
+  case "$cpu_arch_line" in
+    *x86_64*)
+      echo "x64"
+      ;;
+    *armv7*)
+      echo "arm"
+      ;;
+    *armv8*) # unconfirmed
+      echo "aarch64"
+      ;;
+    *)
+      echo "Unknown processor architecture. Please file a bug report."
+      ;;
+  esac
+}
+
 function set_java_17 () {
   if ! [ -d /usr/lib/jvm/jdk-17* ]; then
-    echo "Downloading JDK 1.17"
-    curl -L https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz  | tar xz -C /usr/lib/jvm
+    CPU_ARCH=$(get_cpu_arch_for_java)
+    echo "Downloading JDK 1.17 $CPU_ARCH"
+    curl -L "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_${CPU_ARCH}_linux_hotspot_17.0.2_8.tar.gz"  | tar xz -C /usr/lib/jvm
   fi
 
   echo "set java version to 17"
@@ -21,8 +41,9 @@ function set_java_17 () {
 
 function set_java_16 () {
   if ! [ -d /usr/lib/jvm/jdk-16* ]; then
-    echo "Downloading JDK 1.16"
-    curl -L https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz  | tar xz -C /usr/lib/jvm
+    CPU_ARCH=$(get_cpu_arch_for_java)
+    echo "Downloading JDK 1.16 $CPU_ARCH"
+    curl -L "https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_${CPU_ARCH}_linux_hotspot_16.0.2_7.tar.gz"  | tar xz -C /usr/lib/jvm
   fi
 
   echo "set java version to 16"
@@ -33,11 +54,12 @@ function set_java_16 () {
 
 function set_java_11 () {
   if ! [ -d /usr/lib/jvm/jdk-11* ]; then
-    echo "Downloading JDK 1.11"
-    curl -L https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz  | tar xz -C /usr/lib/jvm
+    CPU_ARCH=$(get_cpu_arch_for_java)
+    echo "Downloading JDK 1.11 $CPU_ARCH"
+    curl -L "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14.1%2B1/OpenJDK11U-jdk_${CPU_ARCH}_linux_hotspot_11.0.14.1_1.tar.gz"  | tar xz -C /usr/lib/jvm
   fi
 
-  echo "set java version to 16"
+  echo "set java version to 11"
   rm -f /usr/lib/jvm/default-jvm 
   ln -s /usr/lib/jvm/jdk-11* /usr/lib/jvm/default-jvm
 
@@ -45,8 +67,9 @@ function set_java_11 () {
 
 function set_java_8 () {
   if ! [ -d /usr/lib/jvm/jdk8* ]; then
-    echo "Downloading JDK 1.8"
-    curl -L https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_x64_linux_hotspot_8u312b07.tar.gz  | tar xz -C /usr/lib/jvm
+    CPU_ARCH=$(get_cpu_arch_for_java)
+    echo "Downloading JDK 1.8 $CPU_ARCH"
+    curl -L "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u322-b06/OpenJDK8U-jdk_${CPU_ARCH}_linux_hotspot_8u322b06.tar.gz"  | tar xz -C /usr/lib/jvm
   fi
 
   echo "set java version to 8"
@@ -74,7 +97,7 @@ case "$1" in
     echo "set_java_ver <version>"
     echo "set the java version for the container"
     echo 
-    echo "Available versions are 8, 11, 16 and 17"
+    echo "Available versions is 8, 11, 16 and 17"
     exit 1
   ;;
 esac


### PR DESCRIPTION
Note: This depends on the image nimmis/ubuntu being rebuilt with multiarch support

This uses docker buildx and manifest lists to build a multiple versions of an image
for different systems which appear as a single image on the docker hub.
This allows clients to select the right version automatically.

Changes:
- Select the right cpu arch version when downloading java
- Replace the java install in the Dockerfile with a call to set_java_ver
- README updated on how to build these images

Possible problems:
I can't quite test this without your ubuntu image being multiarch but my fork which depends on debian allows the server to run on a 32 bit Raspberry Pi.

Java install in the docker file only is affected by the major version variable now. I don't know if the minor versions are necessary. Otherwise not installing java during the build also works as the client can download a copy.

The architecture aarch64 isn't tested as I don't have access to a machine to see the lscpu output. It seems like it should output "armv8".