### PR TITLE
Convert $EULA to lowercase

### DIFF
--- a/rootfs/etc/my_runalways/90_eula
+++ b/rootfs/etc/my_runalways/90_eula
@@ -6,7 +6,7 @@
 
 if [ ! -z $EULA ] ; then
   
-  echo "eula=$EULA" > $SPIGOT_HOME/eula.txt
+  echo "eula=${EULA,,}" > $SPIGOT_HOME/eula.txt
   chown minecraft $SPIGOT_HOME/eula.txt 
 
 fi 


### PR DESCRIPTION
As a way to mitigate the user error in #55, this automatically converts the EULA environment variable to lowercase using [special bash syntax](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html). Tested this locally and it works as expected. 