### PR TITLE
update container to handle 1.19

### DIFF
--- a/rootfs/usr/local/bin/set_java_ver
+++ b/rootfs/usr/local/bin/set_java_ver
@@ -6,6 +6,19 @@
 # (c) 2021 nimmis <kjell.havneskold@gmail.com>
 #
 ###########################################################
+function set_java_18 () {
+  if ! [ -d /usr/lib/jvm/jdk-18* ]; then
+    echo "Downloading JDK 1.18"
+    curl -L https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_x64_linux_hotspot_18.0.1_10.tar.gz  | tar xz -C /usr/lib/jvm
+  fi
+
+  echo "set java version to 17"
+  rm -f /usr/lib/jvm/default-jvm
+  ln -s /usr/lib/jvm/jdk-18* /usr/lib/jvm/default-jvm
+
+}
+
+
 function set_java_17 () {
   if ! [ -d /usr/lib/jvm/jdk-17* ]; then
     echo "Downloading JDK 1.17"

--- a/rootfs/usr/local/bin/set_java_ver
+++ b/rootfs/usr/local/bin/set_java_ver
@@ -12,7 +12,7 @@ function set_java_18 () {
     curl -L https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_x64_linux_hotspot_18.0.1_10.tar.gz  | tar xz -C /usr/lib/jvm
   fi
 
-  echo "set java version to 17"
+  echo "set java version to 18"
   rm -f /usr/lib/jvm/default-jvm
   ln -s /usr/lib/jvm/jdk-18* /usr/lib/jvm/default-jvm
 

--- a/rootfs/usr/local/bin/set_mc_ver
+++ b/rootfs/usr/local/bin/set_mc_ver
@@ -17,7 +17,11 @@ fi
 function load_java() {
 
   case "$1" in
-    latest | 1.18*)
+    latest | 1.19*)
+      /usr/local/bin/set_java_ver 18
+      ;;
+  
+    1.18*)
       /usr/local/bin/set_java_ver 17
       ;;
 


### PR DESCRIPTION
Updates the container to handle 1.19 running on OpenJDK 18. Tested using 1.19, works well. Let me know if it needs further changes.